### PR TITLE
Temporary fix to log EMB Bursts.

### DIFF
--- a/DMRRX/DMRRX.cpp
+++ b/DMRRX/DMRRX.cpp
@@ -89,7 +89,8 @@ m_type(SYNC_NONE),
 m_receiving(false),
 m_buffer(NULL),
 m_shortN(0U),
-m_shortLC(NULL)
+m_shortLC(NULL),
+m_n(0U)
 {
 	m_buffer  = new unsigned char[DMR_FRAME_LENGTH_BYTES];
 	m_shortLC = new unsigned char[9U];
@@ -185,10 +186,14 @@ void CDMRRX::processBit(bool b)
 		switch (m_type) {
 		case SYNC_AUDIO:
 			LogMessage("%u [Audio Sync]", m_slotNo);
+			m_n = 0U;
 			break;
 		case SYNC_DATA:
 			processDataSync(m_buffer);
 			break;
+		case SYNC_NONE:
+			m_n++;
+			LogMessage("%u [Burst with no Sync (EMB) %u]", m_slotNo,m_n);
 		default:
 			break;
 		}

--- a/DMRRX/DMRRX.h
+++ b/DMRRX/DMRRX.h
@@ -48,6 +48,7 @@ private:
 	unsigned char* m_buffer;
 	unsigned int   m_shortN;
 	unsigned char* m_shortLC;
+	unsigned int   m_n;
 
 	void decode(const unsigned char* data, unsigned int length);
 	void processBit(bool b);


### PR DESCRIPTION
This simple fix assumes any bursts without Sync are EMB bursts. 
Should really decode the EMB and verify before making this assumption.
